### PR TITLE
Add bounds on CH layers to not try to downloads not existing tiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,12 @@ RUN mkdir -p /pbf
 RUN ./mbutil-master/mb-util --do_compression --image_format=pbf ch.swisstopo.leichte-basiskarte.vt.mbtiles /pbf/basemap
 
 # Runtime image
-FROM openresty/openresty:1.21.4.1-3-alpine-fat
+FROM openresty/openresty:1.21.4.1-8-bullseye-fat
+RUN \
+    . /etc/os-release && \
+    apt-get update && \
+    apt-get --assume-yes upgrade && \
+    apt-get clean
 COPY tiles /usr/share/nginx/html/tiles
 COPY --from=builder /pbf /usr/share/nginx/html/tiles/pbf
 COPY template.lua /usr/local/openresty/site/lualib/resty/template.lua

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,1 +1,1 @@
-c2cciutils[checks,publish]==1.5.6
+c2cciutils[checks,publish]==1.5.7

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,1 +1,1 @@
-c2cciutils==1.1.dev20211215101636
+c2cciutils[checks,publish]==1.5.6

--- a/templates/style.json
+++ b/templates/style.json
@@ -4,15 +4,17 @@
   "name": "lbm_v2.0.0_ch",
   "sources": {
     "swissmaptiles": {
+      "type": "vector",
       "url": "{*PROTOCOL*}://{*HOSTNAME*}{*BASEURL*}/tiles/tiles.json",
-      "type": "vector"
+      "bounds": [5.140299, 45.398122, 11.477436, 48.230617]
     },
     "relief_shading": {
       "type": "raster",
       "tiles": ["{*SWISSTOPO_WMTS_HILLSHADE_URL*}"],
       "tileSize": 256,
       "minzoom": 0,
-      "maxzoom": 22
+      "maxzoom": 22,
+      "bounds": [5.140299, 45.398122, 11.477436, 48.230617]
     }
   },
   "layers": [


### PR DESCRIPTION
Boundaries are https://github.com/geoblocks/proj/blob/master/src/EPSG_2056.js#LL18C35-L18C51 in EPSG:4326

With maplibre, that avoids error 400 on not existing tiles if you are moving out of CH.